### PR TITLE
Removing charset for it's not supported by pdo_pgsql

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -41,7 +41,7 @@ doctrine:
                 dbname:   flybase
                 user:     flybase
                 password: ~
-                charset:  UTF8
+#                charset:  UTF8
     orm:
         auto_generate_proxy_classes: %kernel.debug%
         auto_mapping: true


### PR DESCRIPTION
Only if I remove the charset encoding from the Doctrine configuration can I access _ajax/fbvendor
If I keep the charset encoding I get the following:

request.CRITICAL: Uncaught PHP Exception Doctrine\DBAL\Exception\ConnectionException: "An exception occured in driver: SQLSTATE[08006] [7] ERROR:  Unsupported startup parameter: options" at /srv/http/LabDB/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php line 77 {"exception":"[object] 
